### PR TITLE
"onkeypress" fallback for "oninput" and password field evaluation

### DIFF
--- a/h5f.js
+++ b/h5f.js
@@ -12,7 +12,7 @@ var H5F = H5F || {};
 (function(d){
     
     var field = d.createElement("input"),
-        emailPatt = new RegExp("([a-z0-9_.-]+)@([0-9a-z.-]+).([a-z.]{2,6})","i"), 
+        emailPatt = new RegExp("^([a-z0-9_.-]+)@([0-9a-z.-]+).([a-z.]{2,6})$","i"), 
         urlPatt = new RegExp("[a-z][-\.+a-z]*:\/\/","i"),
         usrPatt, curEvt, args;
     


### PR DESCRIPTION
The script does not perform validation on older browser like Internet Explorer since they don't support "oninput" event. I have added a conditional "onkeypress" fallback for situations like this.

The script does not evaluate patterns on password fields though Google Chrome does it. Also HTML5 spec does not mention anything about not evaluating patterns on password fields.
