### PR TITLE
[patch] stop force focusing blank required input

### DIFF
--- a/h5f.js
+++ b/h5f.js
@@ -144,7 +144,6 @@ var H5F = H5F || {};
                 if(ff.nodeName !== "FIELDSET" && (isRequired || hasPattern)) {
                     H5F.checkField(ff);
                     if(!ff.validity.valid && !invalid) {
-                        ff.focus();
                         invalid = true;
                     }
                 }


### PR DESCRIPTION
I removed 1 line to stop to force focusing blank required input.
When there are 2 or more required input fields, this line makes the first one focused even if the user wants to move different input.
The behavior is different from native html5 supported browsers.
