### PR TITLE
Find CommonJS in a lint-friendly way

### DIFF
--- a/src/H5F.js
+++ b/src/H5F.js
@@ -6,7 +6,7 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(factory);
-    } else if (typeof module == 'object' && module.exports)  {
+    } else if (typeof module !== 'undefined' && module.exports)  {
         // CommonJS
         module.exports = factory();
     } else {


### PR DESCRIPTION
Travis is failing because of a lint error on double equals from #58 . This is a better way of determining CommonJS.
