### PR TITLE
Add placeholder class when input value matches placeholder attribute value on page load.

### DIFF
--- a/src/H5F.js
+++ b/src/H5F.js
@@ -231,7 +231,7 @@
             isNative = !!("placeholder" in field);
         
         if(!isNative && node.test(el.nodeName) && !ignoredType.test(el.type)) {
-            if(el.value === "" && !focus.test(curEvt)) {
+            if((el.value === "" || el.value === attrs.placeholder) && !focus.test(curEvt)) {
                 el.value = attrs.placeholder;
                 listen(el.form,'submit', function () {
                   curEvt = 'submit';


### PR DESCRIPTION
Hey,

I was having some trouble with placeholder styling in IE9. Steps to recreate were about like this:
- Load the page.
- Setup finds all elements with placeholder attribute and sets their values to the value of the placeholder attribute.
- Reload the page.
- IE9 (at least, but possibly other browsers too) maintains any input values that the user set when reloading
- So on page load, the inputs all have values equal to their placeholder attributes.
- Setup calls placeholder on all elements w/ the attribute set.
- When it gets to line 234, the value was not empty and the field is not focused, so the class does not get added and the field does not get the placeholder styles.

The fix I came up with was to check if the value is empty _OR equal to the placeholder_. On page reload, the value is equal, so it applies the class correctly.
