### PR TITLE
Adds bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,45 @@
+{
+  "name": "H5F",
+  "description": "A JavaScript library that allows you to use the HTML5 Forms chapters new field input types, attributes and constraint validation API in non-supporting browsers",
+  "main": [
+    "src/H5F.js"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "html5",
+    "forms",
+    "validation"
+  ],
+  "authors": [
+    "Ryan Seddon (http://www.thecssninja.com)"
+  ],
+  "homepage": "http://www.thecssninja.com/javascript/H5F",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryanseddon/H5F.git"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.0",
+    "grunt-contrib-concat": "0.1.2rc6",
+    "grunt-contrib-qunit": "~0.2.0",
+    "grunt-contrib-uglify": "0.1.2",
+    "grunt-contrib-jshint": "0.1.1rc6",
+    "grunt-contrib-watch": "~0.3.1",
+    "grunt-contrib-connect": "~0.5.0",
+    "grunt-saucelabs": "~4.0.4",
+    "matchdep": "~0.1.2"
+  },
+  "version": "1.1.1",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Automated tools (like `grunt-bower-install`) use the `bower.json` meta file to discover which assets to inject in the build process.
